### PR TITLE
Build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,15 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
+    - run: npm run build
     - run: npm test
+    - name: Archive JS build
+      uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: lib
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-coverage-report
+        path: coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,16 @@ jobs:
         npm ci
         npm test
         npm pack
+    - name: Archive JS build
+      uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: lib
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-coverage-report
+        path: coverage
     - name: Create Release
       uses: actions/create-release@v1
       id: create_release

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "build": "rm -rf ./lib && tsc",
         "test": "jest --coverage",
-        "prepack": "npm run build && npm test"
+        "prepack": "npm run build"
     },
     "author": "Andrew Goodman",
     "license": "MIT",


### PR DESCRIPTION
Remove duplicated test run - removing tie between packing and test running (it's covered by actions). Run ts build on commit - want to check the typescript compiles (finding out at time of publishing is a bit late). Add build artifacts for lib and coverage.